### PR TITLE
add Publish Egress tag to ec2 instance

### DIFF
--- a/terraform/teamserver_ec2.tf
+++ b/terraform/teamserver_ec2.tf
@@ -1,6 +1,6 @@
 # The bastion EC2 instance
 locals {
-  tags = "${merge(var.tags, map("Name", "PCA Teamserver"))}"
+  tags = "${merge(var.tags, map("Name", "PCA Teamserver", "Publish Egress", "True"))}"
 }
 
 resource "aws_instance" "teamserver" {


### PR DESCRIPTION
Added `Publish Egress` tags so instances will be picked up by egress publication.

See: https://github.com/dhs-ncats/cyhy_amis/pull/72


