### PR TITLE
License and update Cobalt Strike at deployment time

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,14 @@
 
 Build AMI via Packer with:
 ```
-packer-io packer/teamserver.json
+packer packer/teamserver.json
 ```
 
 Build Terraform infrastructure with:
 ```
 cd terraform
 terraform workspace select <your_workspace>
+terrafrom init --upgrade
 terraform apply -var-file=<your_workspace>.tfvars
 ```
 

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -1,0 +1,21 @@
+---
+- hosts: localhost
+  gather_facts: yes
+  check_mode: no
+  tasks:
+    - name: Add public ip addresses to an dynamic inventory
+      add_host:
+        name: "{{ host }}"
+        groups: "{{ host_groups.split(',') }}"
+
+    - wait_for:
+        port: 22
+        host: "{{ host }}"
+        search_regex: OpenSSH
+
+- hosts: all
+  name: License and upgrade Cobalt Strike
+  become: yes
+  become_method: sudo
+  roles:
+    - cobaltstrike

--- a/ansible/roles/cobaltstrike/README.md
+++ b/ansible/roles/cobaltstrike/README.md
@@ -1,0 +1,40 @@
+cobaltstrike
+============
+
+An Ansible role for licensing and upgrading Cobalt Strike.
+
+Requirements
+------------
+
+None
+
+Role Variables
+--------------
+
+None
+
+Dependencies
+------------
+
+None
+
+Example Playbook
+----------------
+
+Here's how to use it in a playbook:
+
+    - hosts: cobaltstrike
+      become: yes
+      become_method: sudo
+      roles:
+        - cobaltstrike
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+Shane Frasier <jeremy.frasier@beta.dhs.gov>

--- a/ansible/roles/cobaltstrike/defaults/main.yml
+++ b/ansible/roles/cobaltstrike/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for chmod_cyhy_dirs

--- a/ansible/roles/cobaltstrike/handlers/main.yml
+++ b/ansible/roles/cobaltstrike/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for chmod_cyhy_dirs

--- a/ansible/roles/cobaltstrike/meta/main.yml
+++ b/ansible/roles/cobaltstrike/meta/main.yml
@@ -1,0 +1,57 @@
+galaxy_info:
+  author: your name
+  description: your description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Some suggested licenses:
+  # - BSD (default)
+  # - MIT
+  # - GPLv2
+  # - GPLv3
+  # - Apache
+  # - CC-BY
+  license: license (GPLv2, CC-BY, etc)
+
+  min_ansible_version: 1.2
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  # Optionally specify the branch Galaxy will use when accessing the GitHub
+  # repo for this role. During role install, if no tags are available,
+  # Galaxy will use this branch. During import Galaxy will access files on
+  # this branch. If Travis integration is configured, only notifications for this
+  # branch will be accepted. Otherwise, in all cases, the repo's default branch
+  # (usually master) will be used.
+  #github_branch:
+
+  #
+  # platforms is a list of platforms, and each platform has a name and a list of versions.
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/ansible/roles/cobaltstrike/tasks/main.yml
+++ b/ansible/roles/cobaltstrike/tasks/main.yml
@@ -1,0 +1,46 @@
+---
+# tasks file for cobaltstrike
+
+#
+# License Cobalt Strike
+#
+- name: Grab the Cobalt Strike license from S3
+  local_action:
+    module: aws_s3
+    bucket: cobalt-strike-for-pca-teamservers
+    object: cobaltstrike.license
+    dest: /tmp/cobaltstrike.license
+    mode: get
+  become: no
+
+- name: Copy Cobalt Strike license
+  copy:
+    src: /tmp/cobaltstrike.license
+    dest: /root/.cobaltstrike.license
+    mode: 0400
+
+- name: Delete local copy of Cobalt Strike license
+  local_action:
+    module: file
+    path: /tmp/cobaltstrike.license
+    state: absent
+  become: no
+
+
+#
+# Upgrade Cobalt Strike
+#
+# The expect Ansible module requires pexpect
+#
+- name: Install pexpect
+  package:
+    name:
+      - python-pexpect
+ 
+- name: Upgrade Cobalt Strike
+  expect:
+    chdir: /opt/cobaltstrike
+    command: sh ./update
+    echo: yes
+    responses:
+      continue: "yes"

--- a/ansible/roles/cobaltstrike/tasks/main.yml
+++ b/ansible/roles/cobaltstrike/tasks/main.yml
@@ -41,6 +41,8 @@
   expect:
     chdir: /opt/cobaltstrike
     command: sh ./update
-    echo: yes
+    timeout: 300
     responses:
       continue: "yes"
+  async: 300
+  poll: 30

--- a/ansible/roles/cobaltstrike/tests/inventory
+++ b/ansible/roles/cobaltstrike/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/ansible/roles/cobaltstrike/tests/test.yml
+++ b/ansible/roles/cobaltstrike/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - chmod_cyhy_dirs

--- a/ansible/roles/cobaltstrike/vars/main.yml
+++ b/ansible/roles/cobaltstrike/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for chmod_cyhy_dirs

--- a/terraform/teamserver_ec2.tf
+++ b/terraform/teamserver_ec2.tf
@@ -41,6 +41,22 @@ resource "aws_eip_association" "eip_assoc" {
   allocation_id = "${aws_eip.teamserver_eip.id}"
 }
 
+# Provision the teamserver EC2 instance via Ansible
+module "teamserver_ansible_provisioner" {
+  source = "github.com/cloudposse/tf_ansible"
+
+  arguments = [
+    "--user=${var.remote_ssh_user}",
+    "--ssh-common-args='-o StrictHostKeyChecking=no'"
+  ]
+  envs = [
+    "host=${aws_eip.teamserver_eip.public_ip}",
+    "host_groups=cobaltstrike",
+  ]
+  playbook = "../ansible/playbook.yml"
+  dry_run = false
+}
+
 # Extra volume for storing PCA data that we want to be immortal.  I
 # use the prevent_destroy lifecycle element to disallow the
 # destruction of this volume via terraform.


### PR DESCRIPTION
This pull request adds Ansible code to license and update Cobalt Strike when deploying the PCA teamserver to AWS.