### PR TITLE
Use read-only profile to access Terraform remote state

### DIFF
--- a/terraform/remote_state.tf
+++ b/terraform/remote_state.tf
@@ -10,7 +10,7 @@ data "terraform_remote_state" "dns" {
     encrypt        = true
     bucket         = "cisa-cool-terraform-state"
     dynamodb_table = "terraform-state-lock"
-    profile        = "cool-terraform-backend"
+    profile        = "cool-terraform-readstate"
     region         = "us-east-1"
     key            = "cool-dns-cyber.dhs.gov.tfstate"
   }


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR switches to using a read-only profile when accessing the Terraform remote state.

<!--- Describe your changes in detail -->

## 💭 Motivation and Context
There is no need here to use an AWS profile with write access to the Terraform state bucket, since we only need to read data from the remote state.   🔒 LEAST PRIVILEGE YO! 🔒 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
I successfully ran `terraform plan` and verified that the read-only profile had sufficient access.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
