### PR TITLE
Upgrade to Cobalt Strike 4

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # the repo. Unless a later match takes precedence,
 # these owners will be requested for review when someone
 # opens a pull request.
-*       @dav3r @felddy @hillaryj @jsf9k @mcdonnnj @cisagov/team-ois
+* @dav3r @jsf9k

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Build AMI via Packer with:
 
 ```console
-packer packer/teamserver.json
+packer build packer/teamserver.json
 ```
 
 Build Terraform infrastructure with:

--- a/packer/ansible/playbook.yml
+++ b/packer/ansible/playbook.yml
@@ -1,24 +1,28 @@
 ---
 - hosts: all
   name: >
-    Update the base image, install python, add banner, and make journald
-    logs persistent
+    Add banner, add htop, add NVMe support, and make journald logs
+    persistent
   become: yes
   become_method: sudo
   roles:
-    - upgrade
-    - python
-    - nvme
     - banner
     - htop
+    - nvme
     - persist_journald
 
-- hosts: teamserver
+- hosts: all
   name: Install Cobalt Strike and server-setup script
   become: yes
   become_method: sudo
   roles:
-    - cobalt_strike
+    # Cobalt Strike requires that Java be installed, so OpenJDK must
+    # go first.
+    - openjdk
+    - role: cobalt_strike
+      vars:
+        # Use the bucket in the old CyHy account
+        bucket_name: cobalt-strike-for-pca-teamservers
     - server_setup
   tasks:
     - name: Install dnsutils

--- a/packer/ansible/python.yml
+++ b/packer/ansible/python.yml
@@ -1,0 +1,9 @@
+---
+- hosts: all
+  name: Install pip3/python3 and remove pip2/python2
+  become: yes
+  become_method: sudo
+  roles:
+    - pip
+    - python
+    - remove_python2

--- a/packer/ansible/requirements.yml
+++ b/packer/ansible/requirements.yml
@@ -5,14 +5,16 @@
   name: cobalt_strike
 - src: https://github.com/cisagov/ansible-role-htop
   name: htop
-- src: https://github.com/cisagov/ansible-role-oracle-java
-  name: oracle_java
+- src: https://github.com/cisagov/ansible-role-openjdk
+  name: openjdk
 - src: https://github.com/cisagov/ansible-role-nvme
   name: nvme
 - src: https://github.com/cisagov/ansible-role-persist-journald
   name: persist_journald
 - src: https://github.com/cisagov/ansible-role-python
   name: python
+- src: https://github.com/cisagov/ansible-role-remove-python2
+  name: remove_python2
 - src: https://github.com/cisagov/ansible-role-server-setup
   name: server_setup
 - src: https://github.com/cisagov/ansible-role-upgrade

--- a/packer/ansible/upgrade.yml
+++ b/packer/ansible/upgrade.yml
@@ -1,0 +1,7 @@
+---
+- hosts: all
+  name: Upgrade base image
+  become: yes
+  become_method: sudo
+  roles:
+    - upgrade

--- a/packer/teamserver.json
+++ b/packer/teamserver.json
@@ -26,18 +26,34 @@
         "Base_AMI_Name": "{{ .SourceAMIName }}",
         "OS_Version": "Debian Stretch",
         "Release": "Latest",
-        "Team": "NCATS OIS - Development"
+        "Team": "VM Fusion - Development"
       },
       "type": "amazon-ebs"
     }
   ],
   "provisioners": [
     {
-      "groups": [
-        "teamserver"
-      ],
+      "playbook_file": "packer/ansible/upgrade.yml",
+      "type": "ansible"
+    },
+    {
+      "playbook_file": "packer/ansible/python.yml",
+      "type": "ansible"
+    },
+    {
       "playbook_file": "packer/ansible/playbook.yml",
       "type": "ansible"
+    },
+    {
+      "execute_command": "chmod +x {{ .Path }}; sudo env {{ .Vars }} {{ .Path }} ; rm -f {{ .Path }}",
+      "inline": [
+        "sed -i '/^users:/ {N; s/users:.*/users: []/g}' /etc/cloud/cloud.cfg",
+        "rm --force /etc/sudoers.d/90-cloud-init-users",
+        "rm --force /root/.ssh/authorized_keys",
+        "/usr/sbin/userdel --remove --force admin"
+      ],
+      "skip_clean": true,
+      "type": "shell"
     }
   ]
 }


### PR DESCRIPTION
## 🗣 Description

This pull request:
* Fixes a typo in `README.md`
* Add the upgrade and python Ansible playbooks to the `packer` configuration
* Adds a provisioner to remove the `admin` user that `packer` uses to build the AMI
* Upgrades the AMI to use Cobalt Strike 4

## 💭 Motivation and Context

The Kali VMs that the PCA team is using now have only Cobalt Strike 4 installed on them.  The Cobalt Strike 4 UI cannot talk to the Cobalt Strike `teamserver`, so the teamserver image must also have Cobalt Strike 4 installed.

The other changes were just cleanup and modernization I did while I was here.

## 🧪 Testing

I used these changes to successfully build a new PCA teamserver AMI.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
