### PR TITLE
Fix terraform-docs Installation URL in build Workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
             ${{ env.CURL_CACHE_DIR }}/"${TERRAFORM_ZIP}"
           sudo ln -s /opt/terraform/terraform /usr/bin/terraform
       - name: Install Terraform-docs
-        run: GO111MODULE=on go get github.com/segmentio/terraform-docs
+        run: GO111MODULE=on go get github.com/terraform-docs/terraform-docs
       - name: Find and initialize Terraform directories
         run: |
           for path in [[ $(find . -type f -iname "*.tf" -exec dirname "{}" \; \


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description

This PR fixes the URL for installation of `terraform-docs` in the `build` workflow.
<!--- Describe your changes in detail -->

## 💭 Motivation and Context

I saw [apb](https://github.com/cisagov/action-apb) triggered builds failing for this project, and realized that because the [lineage](https://github.com/cisagov/action-lineage) configuration points to [cisagov/skeleton-generic](https://github.com/cisagov/skeleton-generic) it did not get the changes in https://github.com/cisagov/skeleton-tf-module/pull/33
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing

Automated tests pass once more.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
