### PR TITLE
Stop using deprecated provider

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,6 @@ env:
   CURL_CACHE_DIR: ~/.cache/curl
   PIP_CACHE_DIR: ~/.cache/pip
   PRE_COMMIT_CACHE_DIR: ~/.cache/pre-commit
-  TF_CACHE_DIR: .terraform
   RUN_TMATE: ${{ secrets.RUN_TMATE }}
 
 jobs:
@@ -30,10 +29,9 @@ jobs:
           >> $GITHUB_ENV
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.14.2'
+          go-version: '1.15'
       - name: Lookup go cache directory
-        run: |
-          echo "GO_CACHE_DIR=$(go env GOCACHE)" >> $GITHUB_ENV
+        run: echo "GOCACHE_DIR=$(go env GOCACHE)" >> $GITHUB_ENV
       - name: Cache linting environments
         uses: actions/cache@v2
         with:
@@ -41,16 +39,18 @@ jobs:
             ${{ env.PIP_CACHE_DIR }}
             ${{ env.PRE_COMMIT_CACHE_DIR }}
             ${{ env.CURL_CACHE_DIR }}
-            ${{ env.GO_CACHE_DIR }}
-            ${{ env.TF_CACHE_DIR }}
+            ${{ env.GOCACHE_DIR }}
           key: "lint-${{ runner.os }}-\
             py${{ env.PY_VERSION }}-\
+            go${{ env.GO_VERSION }}-\
             tf${{ env.TERRAFORM_VERSION }}-\
             ${{ hashFiles('**/requirements-test.txt') }}-\
             ${{ hashFiles('**/requirements.txt') }}-\
             ${{ hashFiles('**/.pre-commit-config.yaml') }}"
           restore-keys: |
-            lint-${{ runner.os }}-py${{ env.PY_VERSION }}-\
+            lint-${{ runner.os }}-\
+            py${{ env.PY_VERSION }}-\
+            go${{ env.GO_VERSION }}-\
             tf${{ env.TERRAFORM_VERSION }}-
             lint-${{ runner.os }}-
       - name: Install Terraform
@@ -64,13 +64,16 @@ jobs:
           sudo unzip -d /opt/terraform \
             ${{ env.CURL_CACHE_DIR }}/"${TERRAFORM_ZIP}"
           sudo ln -s /opt/terraform/terraform /usr/bin/terraform
+          sudo mv /usr/local/bin/terraform /usr/local/bin/terraform-default
+          sudo ln -s /opt/terraform/terraform /usr/local/bin/terraform
       - name: Install Terraform-docs
         run: GO111MODULE=on go get github.com/terraform-docs/terraform-docs
       - name: Find and initialize Terraform directories
         run: |
-          for path in [[ $(find . -type f -iname "*.tf" -exec dirname "{}" \; \
-            | sort -u) ]]; do \
-            terraform init -upgrade=true -input=false -backend=false "$path"; \
+          for path in $(find . -not \( -type d -name ".terraform" -prune \) \
+            -type f -iname "*.tf" -exec dirname "{}" \; | sort -u); do \
+            echo "Initializing '$path'..."; \
+            terraform init -input=false -backend=false "$path"; \
             done
       - name: Install dependencies
         run: |
@@ -78,23 +81,8 @@ jobs:
           pip install --upgrade --requirement requirements-test.txt
       - name: Set up pre-commit hook environments
         run: pre-commit install-hooks
-      - name: Create modified GitHub Actions pre-commit configuration
-        run: |
-          sed '/terraform_validate/d' < .pre-commit-config.yaml \
-          > /tmp/.github-actions-pre-commit-config.yaml
-      - name: Run pre-commit with modified configuration file on all files
-        # We run pre-commit here with a custom configuration that has
-        # the terraform-validate hook removed.  This is because
-        # terraform validate cannot currently run without accessing
-        # the remote state because of the way the providers are
-        # defined in providers.tf.  This is something that may be
-        # remedied in the future.  For more information, check out
-        # these two GitHub issues:
-        # * https://github.com/hashicorp/terraform/issues/15895
-        # * https://github.com/hashicorp/terraform/issues/15811
-        run: |
-          pre-commit run --all-files \
-          --config=/tmp/.github-actions-pre-commit-config.yaml
+      - name: Run pre-commit on all files
+        run: pre-commit run --all-files
       - name: Setup tmate debug session
         uses: mxschmitt/action-tmate@v1
         if: env.RUN_TMATE

--- a/terraform/teamserver_cloud_init.tf
+++ b/terraform/teamserver_cloud_init.tf
@@ -1,32 +1,25 @@
 # cloud-init commands for configuring non-root volumes and ssh
 
-data "template_file" "user_ssh_setup" {
-  template = file("scripts/user_ssh_setup.yml")
-}
-
-data "template_file" "disk_setup" {
-  template = file("scripts/disk_setup.yml")
-
-  vars = {
-    device = "/dev/nvme1n1"
-  }
-}
-
-data "template_cloudinit_config" "teamserver_cloud_init_tasks" {
+data "cloudinit_config" "teamserver_cloud_init_tasks" {
   gzip          = true
   base64_encode = true
 
   part {
     filename     = "user_ssh_setup.yml"
     content_type = "text/cloud-config"
-    content      = data.template_file.user_ssh_setup.rendered
-    merge_type   = "list(append)+dict(recurse_array)+str()"
+    content = templatefile(
+      "${path.module}/scripts/user_ssh_setup.yml",
+    {})
+    merge_type = "list(append)+dict(recurse_array)+str()"
   }
 
   part {
     filename     = "disk_setup.yml"
     content_type = "text/cloud-config"
-    content      = data.template_file.disk_setup.rendered
-    merge_type   = "list(append)+dict(recurse_array)+str()"
+    content = templatefile(
+      "${path.module}/scripts/disk_setup.yml", {
+        device = "/dev/nvme1n1"
+    })
+    merge_type = "list(append)+dict(recurse_array)+str()"
   }
 }

--- a/terraform/teamserver_ec2.tf
+++ b/terraform/teamserver_ec2.tf
@@ -42,7 +42,7 @@ resource "aws_instance" "teamserver" {
     aws_security_group.teamserver.id,
   ]
 
-  user_data_base64 = data.template_cloudinit_config.teamserver_cloud_init_tasks.rendered
+  user_data_base64 = data.cloudinit_config.teamserver_cloud_init_tasks.rendered
 
   tags        = local.tags
   volume_tags = local.tags

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,4 +1,12 @@
-
 terraform {
-  required_version = ">= 0.12"
+  # We want to hold off on 0.13 until we have tested it.
+  required_version = "~> 0.12.0"
+
+  # If you use any other providers you should also pin them to the
+  # major version currently being used.  This practice will help us
+  # avoid unwelcome surprises.
+  required_providers {
+    aws       = "~> 3.0"
+    cloudinit = "~> 2.0"
+  }
 }


### PR DESCRIPTION
## 🗣 Description

This pull request gets rid of the deprecated [template Terraform provider](https://registry.terraform.io/providers/hashicorp/template/latest/docs) in favor of the [cloudinit Terraform provider](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs).

## 💭 Motivation and Context

The deprecated template provider could disappear altogether at any time.

## 🧪 Testing

All pre-commit hooks pass.  I have also used these changes to successfully deploy a new teamserver instance to the CyHy AWS environment.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [x] Halt the ever-advancing threat of obsolescence

## ✅ Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
