### PR TITLE
Do not upgrade Cobalt Strike when building the AMI

### DIFF
--- a/packer/ansible/requirements.yml
+++ b/packer/ansible/requirements.yml
@@ -3,6 +3,7 @@
   name: banner
 - src: https://github.com/cisagov/ansible-role-cobalt-strike
   name: cobalt_strike
+  version: bugfix/do-not-update
 - src: https://github.com/cisagov/ansible-role-htop
   name: htop
 - src: https://github.com/cisagov/ansible-role-nvme


### PR DESCRIPTION
## 🗣 Description ##

This pull request uses a particular branch of [cisagov/ansible-role-cobalt-strike](https://github.com/cisagov/ansible-role-cobalt-strike) to avoid upgrade Cobalt Strike during the AMI build process.

## 💭 Motivation and context ##

The latest Cobalt Strike (4.3) has a bug that affects PCAs; therefore we cannot upgrade beyond version 4.2 at the moment. I have also replaced our Cobalt Strike tarballs in S3 with a new one that contains version 4.2.

Another issue is that our license was recently renewed. The update process creates a new `cobaltstrike.auth` file with an updated license end date.  Without updating Cobalt Strike we will not have the updated `cobaltstrike.auth` file. The new tarball I have put in S3 contains a `cobaltstrike.auth` file with the license end date already updated.

Once a version of Cobalt Strike with a fix for the bug is released we can go back to upgrading Cobalt Strike.

## 🧪 Testing ##

All `pre-commit` hooks pass.  I successfully built, deployed, and tested a new AMI using these changes.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [ ] _All_ future TODOs are captured in issues, which are referenced in code comments.
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
* [ ] All new and existing tests pass.
