### PR TITLE
Bump version of go used in GH Actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
           python-version: 3.9
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15'
+          go-version: '1.16'
       - name: Store installed Go version
         run: |
           echo "GO_VERSION="\


### PR DESCRIPTION
## 🗣 Description ##

This pull request bumps the version of `go` used in the GitHub Actions workflow to 1.16.  This is identical to the change made in cisagov/skeleton-packer#69.

## 💭 Motivation and context ##

The workflow fails without this change.

## 🧪 Testing ##

I verified that the workflow successfully executes with this change.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
